### PR TITLE
fix: remove seed from DEFAULT_MODEL_CONFIG for Google API compatibility

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -58,8 +58,12 @@ model:
   - openai/gpt-oss-120b
 
 # Optional OpenAI client parameters passed to chat completions.
-# Common options: seed, temperature, max_tokens, parallel_tool_calls
+# Common options: temperature, max_tokens, parallel_tool_calls
 # The `extra_body` field passes provider-specific parameters (e.g., OpenRouter).
+#
+# NOTE: You can add `seed` for mostly-deterministic outputs with providers that
+# support it (e.g. OpenAI), but note that some providers (e.g. Google) reject the
+# `seed` parameter with a 400 error. Use it only if you know your provider supports it.
 model_config:
   extra_body:
     usage:

--- a/src/balatrollm/config.py
+++ b/src/balatrollm/config.py
@@ -16,7 +16,6 @@ STRATEGIES_DIR = Path(__file__).parent / "strategies"
 ################################################################################
 
 DEFAULT_MODEL_CONFIG: dict[str, bool | int | str | dict] = {
-    "seed": 1,
     "parallel_tool_calls": False,
     "tool_choice": "auto",
     "extra_headers": {


### PR DESCRIPTION
## Summary

- Removes `"seed": 1` from `DEFAULT_MODEL_CONFIG` in `config.py`
- Google's OpenAI-compatible endpoint (`generativelanguage.googleapis.com/v1beta/openai/`) rejects requests containing the `seed` parameter with `400 INVALID_ARGUMENT: Unknown name "seed": Cannot find field`
- This caused every LLM call to fail after 3 retries when using Google's API directly

## Root cause

`DEFAULT_MODEL_CONFIG` included `"seed": 1` as a default to encourage reproducible LLM outputs. However, `seed` is not part of the OpenAI-compatible spec that Google's API implements, so it is rejected as an unknown field.

## Fix

Remove `seed` from the hardcoded defaults. Users who want deterministic outputs on providers that support it (OpenAI, OpenRouter) can still set `seed` via `model_config` in their YAML config.

## Test plan

- [x] Run `balatrollm` with `BALATROLLM_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/` and a Gemini model — LLM calls should succeed instead of exhausting retries with 400 errors
- [x] Run `balatrollm` with OpenRouter/OpenAI to confirm no regression